### PR TITLE
fix testimonials, job title cropped at the bottom

### DIFF
--- a/themes/hugo-universal-theme/static/css/custom.css
+++ b/themes/hugo-universal-theme/static/css/custom.css
@@ -1,5 +1,10 @@
 /* your styles go here */
 
+/* fix testimonials, job title cropped at the bottom */
+.testimonials .item {
+    padding-bottom: 100px;
+}
+
 .box-image-text .image {
   min-height: 200px;
   max-height: 200px;


### PR DESCRIPTION
The size of the items is recalculated by the javascript on every window resize. Currently the job title was cropped on some devices and not properly recalculated. This is just a workaround adding more whitespace. To fit the calculations you need to better understand how the JS gets the size and how the inserted divs need to have better marked up with padding/margin.